### PR TITLE
Reduce `.clone()`ing

### DIFF
--- a/native/bivar_commitment.rs
+++ b/native/bivar_commitment.rs
@@ -28,9 +28,7 @@ fn eval_bivar_commitment(bvc: BivarCommitmentArc, x: i64, y: i64) -> G1Arc {
 
 #[rustler::nif(name = "row_bivar_commitment")]
 fn row_bivar_commitment(bvc: BivarCommitmentArc, x: i64) -> CommitmentArc {
-    ResourceArc::new(CommitmentRes {
-        commitment: bvc.0.row(x.into_fr()),
-    })
+    ResourceArc::new(CommitmentRes(bvc.0.row(x.into_fr())))
 }
 
 #[rustler::nif(name = "cmp_bivar_commitment")]

--- a/native/bivar_commitment.rs
+++ b/native/bivar_commitment.rs
@@ -5,9 +5,7 @@ use threshold_crypto::poly::BivarCommitment;
 use threshold_crypto::IntoFr;
 
 /// Struct to hold BivariateCommitment (a commitment over a bivar_poly)
-pub struct BivarCommitmentRes {
-    pub bicommitment: BivarCommitment,
-}
+pub struct BivarCommitmentRes(pub(crate) BivarCommitment);
 
 pub type BivarCommitmentArc = ResourceArc<BivarCommitmentRes>;
 
@@ -17,36 +15,30 @@ pub fn load(env: Env) -> bool {
 }
 
 #[rustler::nif(name = "degree_bivar_commitment")]
-fn degree_bivar_commitment(c_arc: BivarCommitmentArc) -> usize {
-    let bicommitment = c_arc.bicommitment.clone();
-    bicommitment.degree()
+fn degree_bivar_commitment(bvc: BivarCommitmentArc) -> usize {
+    bvc.0.degree()
 }
 
 #[rustler::nif(name = "eval_bivar_commitment")]
-fn eval_bivar_commitment(c_arc: BivarCommitmentArc, x: i64, y: i64) -> G1Arc {
-    let bicommitment = c_arc.bicommitment.clone();
+fn eval_bivar_commitment(bvc: BivarCommitmentArc, x: i64, y: i64) -> G1Arc {
     ResourceArc::new(G1Res {
-        g1: bicommitment.evaluate(x.into_fr(), y.into_fr()),
+        g1: bvc.0.evaluate(x.into_fr(), y.into_fr()),
     })
 }
 
 #[rustler::nif(name = "row_bivar_commitment")]
-fn row_bivar_commitment(c_arc: BivarCommitmentArc, x: i64) -> CommitmentArc {
-    let bicommitment = c_arc.bicommitment.clone();
+fn row_bivar_commitment(bvc: BivarCommitmentArc, x: i64) -> CommitmentArc {
     ResourceArc::new(CommitmentRes {
-        commitment: bicommitment.row(x.into_fr()),
+        commitment: bvc.0.row(x.into_fr()),
     })
 }
 
 #[rustler::nif(name = "cmp_bivar_commitment")]
-fn cmp_bivar_commitment(c1_arc: BivarCommitmentArc, c2_arc: BivarCommitmentArc) -> bool {
-    let c1 = c1_arc.bicommitment.clone();
-    let c2 = c2_arc.bicommitment.clone();
-    c1 == c2
+fn cmp_bivar_commitment(bvc1: BivarCommitmentArc, bvc2: BivarCommitmentArc) -> bool {
+    bvc1.0 == bvc2.0
 }
 
 #[rustler::nif(name = "reveal_bivar_commitment")]
-fn reveal_bivar_commitment(c_arc: BivarCommitmentArc) -> String {
-    let bicommitment = c_arc.bicommitment.clone();
-    bicommitment.reveal()
+fn reveal_bivar_commitment(bvc: BivarCommitmentArc) -> String {
+    bvc.0.reveal()
 }

--- a/native/bivar_poly.rs
+++ b/native/bivar_poly.rs
@@ -49,15 +49,13 @@ fn eval_bivar_poly(p_arc: BivarPolyArc, x: i64, y: i64) -> FrArc {
 #[rustler::nif(name = "row_bivar_poly")]
 fn row_bivar_poly(p_arc: BivarPolyArc, x: i64) -> PolyArc {
     let bipoly = p_arc.bipoly.clone();
-    ResourceArc::new(PolyRes (bipoly.row(x.into_fr())))
+    ResourceArc::new(PolyRes(bipoly.row(x.into_fr())))
 }
 
 #[rustler::nif(name = "commitment_bivar_poly")]
 fn commitment_bivar_poly(p_arc: BivarPolyArc) -> BivarCommitmentArc {
     let bipoly = p_arc.bipoly.clone();
-    ResourceArc::new(BivarCommitmentRes {
-        bicommitment: bipoly.commitment(),
-    })
+    ResourceArc::new(BivarCommitmentRes(bipoly.commitment()))
 }
 
 #[rustler::nif(name = "zeroize_bivar_poly")]

--- a/native/bivar_poly.rs
+++ b/native/bivar_poly.rs
@@ -7,9 +7,7 @@ use threshold_crypto::IntoFr;
 use zeroize::Zeroize;
 
 /// Struct to hold Bivariate Polynomial
-pub struct BivarPolyRes {
-    pub bipoly: BivarPoly,
-}
+pub struct BivarPolyRes(pub(crate) BivarPoly);
 
 pub type BivarPolyArc = ResourceArc<BivarPolyRes>;
 
@@ -21,54 +19,45 @@ pub fn load(env: Env) -> bool {
 #[rustler::nif(name = "random_bivar_poly")]
 fn random_bivar_poly(degree: usize) -> BivarPolyArc {
     let rng = &mut rand::thread_rng();
-    ResourceArc::new(BivarPolyRes {
-        bipoly: BivarPoly::random(degree, rng),
-    })
+    ResourceArc::new(BivarPolyRes(BivarPoly::random(degree, rng)))
 }
 
 #[rustler::nif(name = "degree_bivar_poly")]
-fn degree_bivar_poly(p_arc: BivarPolyArc) -> usize {
-    let bipoly = p_arc.bipoly.clone();
-    bipoly.degree()
+fn degree_bivar_poly(bvp: BivarPolyArc) -> usize {
+    bvp.0.degree()
 }
 
 #[rustler::nif(name = "reveal_bivar_poly")]
-fn reveal_bivar_poly(p_arc: BivarPolyArc) -> String {
-    let bipoly = p_arc.bipoly.clone();
-    bipoly.reveal()
+fn reveal_bivar_poly(bvp: BivarPolyArc) -> String {
+    bvp.0.reveal()
 }
 
 #[rustler::nif(name = "eval_bivar_poly")]
-fn eval_bivar_poly(p_arc: BivarPolyArc, x: i64, y: i64) -> FrArc {
-    let bipoly = p_arc.bipoly.clone();
+fn eval_bivar_poly(bvp: BivarPolyArc, x: i64, y: i64) -> FrArc {
     ResourceArc::new(FrRes {
-        fr: bipoly.evaluate(x.into_fr(), y.into_fr()),
+        fr: bvp.0.evaluate(x.into_fr(), y.into_fr()),
     })
 }
 
 #[rustler::nif(name = "row_bivar_poly")]
-fn row_bivar_poly(p_arc: BivarPolyArc, x: i64) -> PolyArc {
-    let bipoly = p_arc.bipoly.clone();
-    ResourceArc::new(PolyRes(bipoly.row(x.into_fr())))
+fn row_bivar_poly(bvp: BivarPolyArc, x: i64) -> PolyArc {
+    ResourceArc::new(PolyRes(bvp.0.row(x.into_fr())))
 }
 
 #[rustler::nif(name = "commitment_bivar_poly")]
-fn commitment_bivar_poly(p_arc: BivarPolyArc) -> BivarCommitmentArc {
-    let bipoly = p_arc.bipoly.clone();
-    ResourceArc::new(BivarCommitmentRes(bipoly.commitment()))
+fn commitment_bivar_poly(bvp: BivarPolyArc) -> BivarCommitmentArc {
+    ResourceArc::new(BivarCommitmentRes(bvp.0.commitment()))
 }
 
 #[rustler::nif(name = "zeroize_bivar_poly")]
-fn zeroize_bivar_poly(p_arc: BivarPolyArc) -> BivarPolyArc {
-    let mut bipoly = p_arc.bipoly.clone();
-    bipoly.zeroize();
-    ResourceArc::new(BivarPolyRes { bipoly: bipoly })
+fn zeroize_bivar_poly(bvp: BivarPolyArc) -> BivarPolyArc {
+    let mut bvp = bvp.0.clone();
+    bvp.zeroize();
+    ResourceArc::new(BivarPolyRes(bvp))
 }
 
 #[rustler::nif(name = "with_secret_bivar_poly")]
 fn with_secret_bivar_poly(secret: u64, degree: usize) -> BivarPolyArc {
     let rng = &mut rand::thread_rng();
-    ResourceArc::new(BivarPolyRes {
-        bipoly: BivarPoly::with_secret(secret, degree, rng),
-    })
+    ResourceArc::new(BivarPolyRes(BivarPoly::with_secret(secret, degree, rng)))
 }

--- a/native/bivar_poly.rs
+++ b/native/bivar_poly.rs
@@ -49,9 +49,7 @@ fn eval_bivar_poly(p_arc: BivarPolyArc, x: i64, y: i64) -> FrArc {
 #[rustler::nif(name = "row_bivar_poly")]
 fn row_bivar_poly(p_arc: BivarPolyArc, x: i64) -> PolyArc {
     let bipoly = p_arc.bipoly.clone();
-    ResourceArc::new(PolyRes {
-        poly: bipoly.row(x.into_fr()),
-    })
+    ResourceArc::new(PolyRes (bipoly.row(x.into_fr())))
 }
 
 #[rustler::nif(name = "commitment_bivar_poly")]

--- a/native/ciphertext.rs
+++ b/native/ciphertext.rs
@@ -2,9 +2,7 @@ use rustler::{Env, ResourceArc};
 use threshold_crypto::Ciphertext;
 
 /// Struct to hold PublicKeyShare
-pub struct CiphertextRes {
-    pub cipher: Ciphertext,
-}
+pub struct CiphertextRes(pub(crate) Ciphertext);
 
 pub type CiphertextArc = ResourceArc<CiphertextRes>;
 
@@ -14,11 +12,11 @@ pub fn load(env: Env) -> bool {
 }
 
 #[rustler::nif(name = "ciphertext_verify")]
-fn ciphertext_verify(cipher_arc: CiphertextArc) -> bool {
-    cipher_arc.cipher.verify()
+fn ciphertext_verify(cipher: CiphertextArc) -> bool {
+    cipher.0.verify()
 }
 
 #[rustler::nif(name = "ciphertext_cmp")]
 fn ciphertext_cmp(c1a: CiphertextArc, c2a: CiphertextArc) -> bool {
-    c1a.cipher == c2a.cipher
+    c1a.0 == c2a.0
 }

--- a/native/commitment.rs
+++ b/native/commitment.rs
@@ -4,9 +4,7 @@ use threshold_crypto::poly::Commitment;
 use threshold_crypto::IntoFr;
 
 /// Struct to hold Commitment
-pub struct CommitmentRes {
-    pub commitment: Commitment,
-}
+pub struct CommitmentRes(pub(crate) Commitment);
 
 pub type CommitmentArc = ResourceArc<CommitmentRes>;
 
@@ -17,36 +15,31 @@ pub fn load(env: Env) -> bool {
 
 #[rustler::nif(name = "degree_commitment")]
 fn degree_commitment(c_arc: CommitmentArc) -> usize {
-    let commitment = c_arc.commitment.clone();
-    commitment.degree()
+    c_arc.0.degree()
 }
 
 #[rustler::nif(name = "eval_commitment")]
 fn eval_commitment(c_arc: CommitmentArc, point: i64) -> G1Arc {
-    let commitment = c_arc.commitment.clone();
     ResourceArc::new(G1Res {
-        g1: commitment.evaluate(point.into_fr()),
+        g1: c_arc.0.evaluate(point.into_fr()),
     })
 }
 
 #[rustler::nif(name = "cmp_commitment")]
 fn cmp_commitment(c1_arc: CommitmentArc, c2_arc: CommitmentArc) -> bool {
-    let c1 = c1_arc.commitment.clone();
-    let c2 = c2_arc.commitment.clone();
+    let c1 = c1_arc.0.clone();
+    let c2 = c2_arc.0.clone();
     c1 == c2
 }
 
 #[rustler::nif(name = "add_commitment")]
 fn add_commitment(c1_arc: CommitmentArc, c2_arc: CommitmentArc) -> CommitmentArc {
-    let c1 = c1_arc.commitment.clone();
-    let c2 = c2_arc.commitment.clone();
-    ResourceArc::new(CommitmentRes {
-        commitment: c1 + c2
-    })
+    let c1 = c1_arc.0.clone();
+    let c2 = c2_arc.0.clone();
+    ResourceArc::new(CommitmentRes(c1 + c2))
 }
 
 #[rustler::nif(name = "reveal_commitment")]
 fn reveal_commitment(c_arc: CommitmentArc) -> String {
-    let commitment = c_arc.commitment.clone();
-    commitment.reveal()
+    c_arc.0.reveal()
 }

--- a/native/pk.rs
+++ b/native/pk.rs
@@ -34,7 +34,7 @@ fn pk_to_bytes<'a>(env: Env<'a>, pk_arc: PkArc) -> Binary<'a> {
 #[rustler::nif(name = "pk_verify")]
 fn pk_verify<'a>(pk_arc: PkArc, sig_arc: SigArc, msg: LazyBinary<'a>) -> bool {
     let pk = pk_arc.pk;
-    let sig = sig_arc.sig.clone();
+    let sig = sig_arc.0.clone();
     pk.verify(&sig, msg)
 }
 

--- a/native/pk.rs
+++ b/native/pk.rs
@@ -41,7 +41,5 @@ fn pk_verify<'a>(pk_arc: PkArc, sig_arc: SigArc, msg: LazyBinary<'a>) -> bool {
 #[rustler::nif(name = "pk_encrypt")]
 fn pk_encrypt<'a>(pk_arc: PkArc, msg: LazyBinary<'a>) -> CiphertextArc {
     let pk = pk_arc.pk;
-    ResourceArc::new(CiphertextRes {
-        cipher: pk.encrypt(&msg),
-    })
+    ResourceArc::new(CiphertextRes(pk.encrypt(&msg)))
 }

--- a/native/pk_set.rs
+++ b/native/pk_set.rs
@@ -56,7 +56,7 @@ fn pk_set_decrypt(
 ) -> (Atom, Bin) {
     let decrypted: Result<Vec<u8>, threshold_crypto::error::Error> = pk_set_arc.pk_set.decrypt(
         dec_shares.iter().map(|(i, dsa)| (*i, &dsa.dec_share)),
-        &cipher_arc.cipher,
+        &cipher_arc.0,
     );
 
     match decrypted {

--- a/native/pk_set.rs
+++ b/native/pk_set.rs
@@ -76,7 +76,7 @@ fn pk_set_combine_signatures<'a>(
         .combine_signatures(sig_shares.iter().map(|(i, sa)| (*i, &sa.sig_share)));
 
     match res {
-        Ok(r) => Ok(ResourceArc::new(SigRes { sig: r }).encode(env)),
+        Ok(r) => Ok(ResourceArc::new(SigRes(r)).encode(env)),
         _ => Ok((error(), cannot_combine()).encode(env)),
     }
 }

--- a/native/pk_set.rs
+++ b/native/pk_set.rs
@@ -25,7 +25,7 @@ pub fn load(env: Env) -> bool {
 #[rustler::nif(name = "pk_set_from_commitment")]
 fn pk_set_from_commitment(c_arc: CommitmentArc) -> PKSetArc {
     ResourceArc::new(PKSetRes {
-        pk_set: PublicKeySet::from(c_arc.commitment.clone()),
+        pk_set: PublicKeySet::from(c_arc.0.clone()),
     })
 }
 

--- a/native/pk_share.rs
+++ b/native/pk_share.rs
@@ -26,7 +26,7 @@ fn pk_share_verify_decryption_share(
     let dec_share = dec_share_arc.dec_share.clone();
     pk_share_arc
         .share
-        .verify_decryption_share(&dec_share, &cipher_arc.cipher)
+        .verify_decryption_share(&dec_share, &cipher_arc.0)
 }
 
 #[rustler::nif(name = "pk_share_verify")]

--- a/native/poly.rs
+++ b/native/poly.rs
@@ -1,6 +1,6 @@
 use crate::commitment::{CommitmentArc, CommitmentRes};
 use crate::fr::{FrArc, FrRes};
-use rustler::{Env, ResourceArc};
+use rustler::{Env, ListIterator, ResourceArc};
 use threshold_crypto::poly::Poly;
 use threshold_crypto::{Fr, IntoFr};
 use zeroize::Zeroize;
@@ -16,9 +16,11 @@ pub fn load(env: Env) -> bool {
 }
 
 #[rustler::nif(name = "poly_from_coeffs")]
-fn poly_from_coeffs(vec: Vec<i64>) -> PolyArc {
-    let coeffs: Vec<Fr> = vec.iter().map(IntoFr::into_fr).collect();
-
+fn poly_from_coeffs<'a>(coeffs: ListIterator<'a>) -> PolyArc {
+    let coeffs = coeffs
+        .map(|coeff| coeff.decode::<i64>().map(IntoFr::into_fr))
+        .collect::<Result<Vec<Fr>, _>>()
+        .expect("expected a list of i64s");
     ResourceArc::new(PolyRes(Poly::from(coeffs)))
 }
 

--- a/native/poly.rs
+++ b/native/poly.rs
@@ -136,7 +136,5 @@ fn reveal_poly(p: PolyArc) -> String {
 
 #[rustler::nif(name = "commitment_poly")]
 fn commitment_poly(p: PolyArc) -> CommitmentArc {
-    ResourceArc::new(CommitmentRes {
-        commitment: p.0.commitment(),
-    })
+    ResourceArc::new(CommitmentRes(p.0.commitment()))
 }

--- a/native/sig.rs
+++ b/native/sig.rs
@@ -3,9 +3,7 @@ use std::io::Write as _;
 use threshold_crypto::Signature;
 
 /// Struct to hold PublicKey
-pub struct SigRes {
-    pub sig: Signature,
-}
+pub struct SigRes(pub(crate) Signature);
 
 pub type SigArc = ResourceArc<SigRes>;
 
@@ -16,7 +14,7 @@ pub fn load(env: Env) -> bool {
 
 #[rustler::nif(name = "sig_to_bytes")]
 fn sig_to_bytes<'a>(env: Env<'a>, sig_arc: SigArc) -> Binary<'a> {
-    let bin_vec = sig_arc.sig.to_bytes();
+    let bin_vec = sig_arc.0.to_bytes();
     let mut binary = OwnedBinary::new(bin_vec.len()).unwrap();
     binary.as_mut_slice().write_all(&bin_vec).unwrap();
     Binary::from_owned(binary, env)
@@ -24,5 +22,5 @@ fn sig_to_bytes<'a>(env: Env<'a>, sig_arc: SigArc) -> Binary<'a> {
 
 #[rustler::nif(name = "sig_parity")]
 fn sig_parity(sig_arc: SigArc) -> bool {
-    sig_arc.sig.parity()
+    sig_arc.0.parity()
 }

--- a/native/sk.rs
+++ b/native/sk.rs
@@ -58,7 +58,7 @@ fn sk_sign<'a>(sk_arc: SkArc, msg: LazyBinary<'a>) -> SigArc {
 
 #[rustler::nif(name = "sk_decrypt")]
 fn sk_decrypt<'a>(env: Env<'a>, sk_arc: SkArc, cipher_arc: CiphertextArc) -> Binary<'a> {
-    let decrypted = sk_arc.sk.decrypt(&cipher_arc.cipher).unwrap();
+    let decrypted = sk_arc.sk.decrypt(&cipher_arc.0).unwrap();
     let mut binary = OwnedBinary::new(decrypted.len()).unwrap();
     binary.as_mut_slice().write_all(&decrypted).unwrap();
     Binary::from_owned(binary, env)

--- a/native/sk.rs
+++ b/native/sk.rs
@@ -53,7 +53,7 @@ fn sk_reveal(sk_arc: SkArc) -> String {
 #[rustler::nif(name = "sk_sign")]
 fn sk_sign<'a>(sk_arc: SkArc, msg: LazyBinary<'a>) -> SigArc {
     let sk = sk_arc.sk.clone();
-    ResourceArc::new(SigRes { sig: sk.sign(msg) })
+    ResourceArc::new(SigRes(sk.sign(msg)))
 }
 
 #[rustler::nif(name = "sk_decrypt")]

--- a/native/sk_set.rs
+++ b/native/sk_set.rs
@@ -1,12 +1,12 @@
-use rustler::{Env, ResourceArc};
+use crate::pk_set::{PKSetArc, PKSetRes};
 use crate::poly::PolyArc;
-use crate::pk_set::{PKSetRes, PKSetArc};
-use crate::sk_share::{SKShareRes, SKShareArc};
+use crate::sk_share::{SKShareArc, SKShareRes};
+use rustler::{Env, ResourceArc};
 use threshold_crypto::SecretKeySet;
 
 /// Struct to hold SecretKeySet
 pub struct SKSetRes {
-    pub sk_set: SecretKeySet
+    pub sk_set: SecretKeySet,
 }
 
 pub type SKSetArc = ResourceArc<SKSetRes>;
@@ -19,7 +19,7 @@ pub fn load(env: Env) -> bool {
 #[rustler::nif(name = "sk_set_from_poly")]
 fn sk_set_from_poly(p_arc: PolyArc) -> SKSetArc {
     ResourceArc::new(SKSetRes {
-        sk_set: SecretKeySet::from(p_arc.poly.clone())
+        sk_set: SecretKeySet::from(p_arc.0.clone()),
     })
 }
 
@@ -31,14 +31,14 @@ fn sk_set_threshold(sk_set_arc: SKSetArc) -> usize {
 #[rustler::nif(name = "sk_set_public_keys")]
 fn sk_set_public_keys(sk_set_arc: SKSetArc) -> PKSetArc {
     ResourceArc::new(PKSetRes {
-        pk_set: sk_set_arc.sk_set.public_keys()
+        pk_set: sk_set_arc.sk_set.public_keys(),
     })
 }
 
 #[rustler::nif(name = "sk_set_secret_key_share")]
 fn sk_set_secret_key_share(sk_set_arc: SKSetArc, i: i64) -> SKShareArc {
     ResourceArc::new(SKShareRes {
-        share: sk_set_arc.sk_set.secret_key_share(i)
+        share: sk_set_arc.sk_set.secret_key_share(i),
     })
 }
 
@@ -46,6 +46,6 @@ fn sk_set_secret_key_share(sk_set_arc: SKSetArc, i: i64) -> SKShareArc {
 fn sk_set_random(threshold: usize) -> SKSetArc {
     let mut rng = &mut rand::thread_rng();
     ResourceArc::new(SKSetRes {
-        sk_set: SecretKeySet::random(threshold, &mut rng)
+        sk_set: SecretKeySet::random(threshold, &mut rng),
     })
 }

--- a/native/sk_share.rs
+++ b/native/sk_share.rs
@@ -20,7 +20,7 @@ pub fn load(env: Env) -> bool {
 #[rustler::nif(name = "sk_share_decryption_share")]
 fn sk_share_decryption_share(sk_share_arc: SKShareArc, cipher_arc: CiphertextArc) -> DecShareArc {
     ResourceArc::new(DecShareRes {
-        dec_share: sk_share_arc.share.decrypt_share(&cipher_arc.cipher).unwrap()
+        dec_share: sk_share_arc.share.decrypt_share(&cipher_arc.0).unwrap()
     })
 }
 


### PR DESCRIPTION
This PR reduces cloning by remiving the custom `Bin` wrapper and by simplifying the `poly`  module. I'm opening this early just to check if you'd like me to do the same to the rest of code crate.