### PR TITLE
Remove unnecessary cloning

### DIFF
--- a/native/commitment.rs
+++ b/native/commitment.rs
@@ -31,9 +31,7 @@ fn eval_commitment(c_arc: CommitmentArc, point: i64) -> G1Arc {
 
 #[rustler::nif(name = "cmp_commitment")]
 fn cmp_commitment(c1_arc: CommitmentArc, c2_arc: CommitmentArc) -> bool {
-    let c1 = c1_arc.0.clone();
-    let c2 = c2_arc.0.clone();
-    c1 == c2
+    c1_arc.0 == c2_arc.0
 }
 
 #[rustler::nif(name = "add_commitment")]

--- a/native/g1.rs
+++ b/native/g1.rs
@@ -21,9 +21,7 @@ fn g1_zero() -> G1Arc {
 
 #[rustler::nif(name = "cmp_g1")]
 fn cmp_g1(g1_arc: G1Arc, g2_arc: G1Arc) -> bool {
-    let g1_1 = g1_arc.g1;
-    let g1_2 = g2_arc.g1;
-    g1_1 == g1_2
+    g1_arc.g1 == g2_arc.g1
 }
 
 #[rustler::nif(name = "g1_random")]

--- a/native/g1_affine.rs
+++ b/native/g1_affine.rs
@@ -23,8 +23,7 @@ fn g1_affine_one() -> G1AffineArc {
 
 #[rustler::nif(name = "g1_affine_mul")]
 fn g1_affine_mul(g1_affine_arc_1: G1AffineArc, fr_arc: FrArc) -> G1Arc {
-    let g1_affine_1 = g1_affine_arc_1.g1_affine.clone();
-    let fr = fr_arc.fr.clone();
-
-    ResourceArc::new(G1Res { g1: g1_affine_1.mul(fr) })
+    ResourceArc::new(G1Res {
+        g1: g1_affine_arc_1.g1_affine.mul(fr_arc.fr),
+    })
 }

--- a/native/pk.rs
+++ b/native/pk.rs
@@ -19,8 +19,7 @@ pub fn load(env: Env) -> bool {
 
 #[rustler::nif(name = "pk_reveal")]
 fn pk_reveal(pk_arc: PkArc) -> String {
-    let pk = pk_arc.pk.clone();
-    pk.reveal()
+    pk_arc.pk.reveal()
 }
 
 #[rustler::nif(name = "pk_to_bytes")]
@@ -33,9 +32,7 @@ fn pk_to_bytes<'a>(env: Env<'a>, pk_arc: PkArc) -> Binary<'a> {
 
 #[rustler::nif(name = "pk_verify")]
 fn pk_verify<'a>(pk_arc: PkArc, sig_arc: SigArc, msg: LazyBinary<'a>) -> bool {
-    let pk = pk_arc.pk;
-    let sig = sig_arc.0.clone();
-    pk.verify(&sig, msg)
+    pk_arc.pk.verify(&sig_arc.0, msg)
 }
 
 #[rustler::nif(name = "pk_encrypt")]

--- a/native/pk_share.rs
+++ b/native/pk_share.rs
@@ -27,10 +27,9 @@ fn pk_share_verify_decryption_share(
     dec_share_arc: DecShareArc,
     cipher_arc: CiphertextArc,
 ) -> bool {
-    let dec_share = dec_share_arc.dec_share.clone();
     pk_share_arc
         .share
-        .verify_decryption_share(&dec_share, &cipher_arc.0)
+        .verify_decryption_share(&dec_share_arc.dec_share, &cipher_arc.0)
 }
 
 #[rustler::nif(name = "pk_share_verify_signature_share")]

--- a/native/poly.rs
+++ b/native/poly.rs
@@ -45,9 +45,8 @@ fn eval_uni_poly(p: PolyArc, point: i64) -> FrArc {
 
 #[rustler::nif(name = "eval_uni_poly_from_fr")]
 fn eval_uni_poly_from_fr(p: PolyArc, point: FrArc) -> FrArc {
-    let point = point.fr.clone();
     ResourceArc::new(FrRes {
-        fr: p.0.evaluate(point),
+        fr: p.0.evaluate(point.fr),
     })
 }
 

--- a/native/sk.rs
+++ b/native/sk.rs
@@ -38,9 +38,8 @@ fn sk_from_fr(fr_arc: FrArc) -> SkArc {
 
 #[rustler::nif(name = "sk_public_key")]
 fn sk_public_key(sk_arc: SkArc) -> PkArc {
-    let sk = sk_arc.sk.clone();
     ResourceArc::new(PkRes {
-        pk: sk.public_key(),
+        pk: sk_arc.sk.public_key(),
     })
 }
 
@@ -51,8 +50,7 @@ fn sk_reveal(sk_arc: SkArc) -> String {
 
 #[rustler::nif(name = "sk_sign")]
 fn sk_sign<'a>(sk_arc: SkArc, msg: LazyBinary<'a>) -> SigArc {
-    let sk = sk_arc.sk.clone();
-    ResourceArc::new(SigRes(sk.sign(msg)))
+    ResourceArc::new(SigRes(sk_arc.sk.sign(msg)))
 }
 
 #[rustler::nif(name = "sk_decrypt")]


### PR DESCRIPTION
This PR removes calls too `.clone()` only where there is no possibility of observable side effects, i.e., we are referencing the previously cloned immutably.