### PR TITLE
Mark known-slow NIFs as dirty (cpu bound)

### DIFF
--- a/native/bivar_commitment.rs
+++ b/native/bivar_commitment.rs
@@ -22,14 +22,14 @@ fn degree_bivar_commitment(bvc: BivarCommitmentArc) -> usize {
     bvc.0.degree()
 }
 
-#[rustler::nif(name = "eval_bivar_commitment")]
+#[rustler::nif(name = "eval_bivar_commitment", schedule = "DirtyCpu")]
 fn eval_bivar_commitment(bvc: BivarCommitmentArc, x: i64, y: i64) -> G1Arc {
     ResourceArc::new(G1Res {
         g1: bvc.0.evaluate(x.into_fr(), y.into_fr()),
     })
 }
 
-#[rustler::nif(name = "row_bivar_commitment")]
+#[rustler::nif(name = "row_bivar_commitment", schedule = "DirtyCpu")]
 fn row_bivar_commitment(bvc: BivarCommitmentArc, x: i64) -> CommitmentArc {
     ResourceArc::new(CommitmentRes(bvc.0.row(x.into_fr())))
 }
@@ -44,14 +44,14 @@ fn reveal_bivar_commitment(bvc: BivarCommitmentArc) -> String {
     bvc.0.reveal()
 }
 
-#[rustler::nif(name = "serialize_bivar_commitment")]
+#[rustler::nif(name = "serialize_bivar_commitment", schedule = "DirtyCpu")]
 pub fn serialize_bivar_commitment(p: BivarCommitmentArc) -> Bin {
     // TODO: Investigate allowing specifying encoding type using an erlang atom
     let bytes = bincode::serialize(&p.0).unwrap();
     Bin(bytes)
 }
 
-#[rustler::nif(name = "deserialize_bivar_commitment")]
+#[rustler::nif(name = "deserialize_bivar_commitment", schedule = "DirtyCpu")]
 pub fn deserialize_bivar_commitment(bin: rustler::Binary) -> BivarCommitmentArc {
     let bvc_res = bincode::deserialize(&bin).unwrap();
     BivarCommitmentArc::new(bvc_res)

--- a/native/bivar_poly.rs
+++ b/native/bivar_poly.rs
@@ -47,7 +47,7 @@ fn row_bivar_poly(bvp: BivarPolyArc, x: i64) -> PolyArc {
     ResourceArc::new(PolyRes(bvp.0.row(x.into_fr())))
 }
 
-#[rustler::nif(name = "commitment_bivar_poly")]
+#[rustler::nif(name = "commitment_bivar_poly", schedule = "DirtyCpu")]
 fn commitment_bivar_poly(bvp: BivarPolyArc) -> BivarCommitmentArc {
     ResourceArc::new(BivarCommitmentRes(bvp.0.commitment()))
 }

--- a/native/ciphertext.rs
+++ b/native/ciphertext.rs
@@ -14,7 +14,7 @@ pub fn load(env: Env) -> bool {
     true
 }
 
-#[rustler::nif(name = "ciphertext_verify")]
+#[rustler::nif(name = "ciphertext_verify", schedule = "DirtyCpu")]
 fn ciphertext_verify(cipher: CiphertextArc) -> bool {
     cipher.0.verify()
 }

--- a/native/fr.rs
+++ b/native/fr.rs
@@ -16,7 +16,7 @@ pub fn load(env: Env) -> bool {
     true
 }
 
-#[rustler::nif(name = "into_fr")]
+#[rustler::nif(name = "into_fr", schedule = "DirtyCpu")]
 fn into_fr(num: i64) -> FrArc {
     ResourceArc::new(FrRes { fr: num.into_fr() })
 }
@@ -50,7 +50,7 @@ fn zero_fr() -> FrArc {
     ResourceArc::new(FrRes { fr: Fr::zero() })
 }
 
-#[rustler::nif(name = "serialize_fr")]
+#[rustler::nif(name = "serialize_fr", schedule = "DirtyCpu")]
 pub fn serialize_fr(fra: FrArc) -> Bin {
     // TODO: Investigate allowing specifying encoding type using an erlang atom
     let wfr = WireFr::from_fr(fra.fr);
@@ -58,7 +58,7 @@ pub fn serialize_fr(fra: FrArc) -> Bin {
     Bin(bytes)
 }
 
-#[rustler::nif(name = "deserialize_fr")]
+#[rustler::nif(name = "deserialize_fr", schedule = "DirtyCpu")]
 pub fn deserialize_fr(bin: rustler::Binary) -> FrArc {
     let wire_fr: WireFr = bincode::deserialize(&bin).unwrap();
     FrArc::new(FrRes {

--- a/native/g1_affine.rs
+++ b/native/g1_affine.rs
@@ -1,8 +1,8 @@
-use rustler::{Env, ResourceArc};
-use crate::g1::{G1Res, G1Arc};
 use crate::fr::FrArc;
-use threshold_crypto::G1Affine;
+use crate::g1::{G1Arc, G1Res};
+use rustler::{Env, ResourceArc};
 use threshold_crypto::group::CurveAffine;
+use threshold_crypto::G1Affine;
 
 /// Struct to hold G1
 pub struct G1AffineRes {
@@ -18,10 +18,12 @@ pub fn load(env: Env) -> bool {
 
 #[rustler::nif(name = "g1_affine_one")]
 fn g1_affine_one() -> G1AffineArc {
-    ResourceArc::new(G1AffineRes { g1_affine: G1Affine::one() })
+    ResourceArc::new(G1AffineRes {
+        g1_affine: G1Affine::one(),
+    })
 }
 
-#[rustler::nif(name = "g1_affine_mul")]
+#[rustler::nif(name = "g1_affine_mul", schedule = "DirtyCpu")]
 fn g1_affine_mul(g1_affine_arc_1: G1AffineArc, fr_arc: FrArc) -> G1Arc {
     ResourceArc::new(G1Res {
         g1: g1_affine_arc_1.g1_affine.mul(fr_arc.fr),

--- a/native/pk.rs
+++ b/native/pk.rs
@@ -22,12 +22,12 @@ fn pk_reveal(pk_arc: PkArc) -> String {
     pk_arc.pk.reveal()
 }
 
-#[rustler::nif(name = "pk_verify")]
+#[rustler::nif(name = "pk_verify", schedule = "DirtyCpu")]
 fn pk_verify<'a>(pk_arc: PkArc, sig_arc: SigArc, msg: LazyBinary<'a>) -> bool {
     pk_arc.pk.verify(&sig_arc.0, msg)
 }
 
-#[rustler::nif(name = "pk_encrypt")]
+#[rustler::nif(name = "pk_encrypt", schedule = "DirtyCpu")]
 fn pk_encrypt<'a>(pk_arc: PkArc, msg: LazyBinary<'a>) -> CiphertextArc {
     let pk = pk_arc.pk;
     ResourceArc::new(CiphertextRes(pk.encrypt(&msg)))

--- a/native/pk_set.rs
+++ b/native/pk_set.rs
@@ -50,7 +50,7 @@ fn pk_set_public_key_share(pk_set_arc: PKSetArc, i: i64) -> PKShareArc {
     })
 }
 
-#[rustler::nif(name = "pk_set_decrypt")]
+#[rustler::nif(name = "pk_set_decrypt", schedule = "DirtyCpu")]
 fn pk_set_decrypt<'a>(
     env: Env<'a>,
     pk_set_arc: PKSetArc,
@@ -68,7 +68,7 @@ fn pk_set_decrypt<'a>(
     }
 }
 
-#[rustler::nif(name = "pk_set_combine_signatures")]
+#[rustler::nif(name = "pk_set_combine_signatures", schedule = "DirtyCpu")]
 fn pk_set_combine_signatures<'a>(
     env: Env<'a>,
     pk_set_arc: PKSetArc,
@@ -98,7 +98,7 @@ pub fn pk_set_serialize(pka: PKSetArc) -> Bin {
     Bin(bytes)
 }
 
-#[rustler::nif(name = "pk_set_deserialize")]
+#[rustler::nif(name = "pk_set_deserialize", schedule = "DirtyCpu")]
 pub fn pk_set_deserialize(bin: rustler::Binary) -> PKSetArc {
     let pk_set_res = bincode::deserialize(&bin).unwrap();
     PKSetArc::new(pk_set_res)

--- a/native/pk_share.rs
+++ b/native/pk_share.rs
@@ -20,7 +20,7 @@ pub fn load(env: Env) -> bool {
     true
 }
 
-#[rustler::nif(name = "pk_share_verify_decryption_share")]
+#[rustler::nif(name = "pk_share_verify_decryption_share", schedule = "DirtyCpu")]
 fn pk_share_verify_decryption_share(
     pk_share_arc: PKShareArc,
     dec_share_arc: DecShareArc,
@@ -31,7 +31,7 @@ fn pk_share_verify_decryption_share(
         .verify_decryption_share(&dec_share_arc.dec_share, &cipher_arc.0)
 }
 
-#[rustler::nif(name = "pk_share_verify_signature_share")]
+#[rustler::nif(name = "pk_share_verify_signature_share", schedule = "DirtyCpu")]
 fn pk_share_verify_signature_share<'a>(
     pk_share_arc: PKShareArc,
     sig_share_arc: SigShareArc,

--- a/native/poly.rs
+++ b/native/poly.rs
@@ -30,13 +30,11 @@ fn poly_from_coeffs<'a>(coeffs: ListIterator<'a>) -> PolyArc {
 #[rustler::nif(name = "poly_from_frs")]
 fn poly_from_frs<'a>(frs: Vec<FrArc>) -> PolyArc {
     ResourceArc::new(PolyRes(Poly::from(
-                frs
-                .iter()
-                .map(|fa| fa.fr)
-                .collect::<Vec<Fr>>())))
+        frs.iter().map(|fa| fa.fr).collect::<Vec<Fr>>(),
+    )))
 }
 
-#[rustler::nif(name = "eval_uni_poly")]
+#[rustler::nif(name = "eval_uni_poly", schedule = "DirtyCpu")]
 fn eval_uni_poly(p: PolyArc, point: i64) -> FrArc {
     ResourceArc::new(FrRes {
         fr: p.0.evaluate(point.into_fr()),
@@ -145,7 +143,7 @@ fn reveal_poly(p: PolyArc) -> String {
     p.0.reveal()
 }
 
-#[rustler::nif(name = "commitment_poly")]
+#[rustler::nif(name = "commitment_poly", schedule = "DirtyCpu")]
 fn commitment_poly(p: PolyArc) -> CommitmentArc {
     ResourceArc::new(CommitmentRes(p.0.commitment()))
 }

--- a/native/sk.rs
+++ b/native/sk.rs
@@ -1,11 +1,11 @@
-use crate::fr::FrArc;
-use crate::pk::{PkArc, PkRes};
 use crate::ciphertext::CiphertextArc;
+use crate::fr::FrArc;
 use crate::lazy_binary::LazyBinary;
+use crate::pk::{PkArc, PkRes};
 use crate::sig::{SigArc, SigRes};
-use rustler::{Env, Binary, OwnedBinary, ResourceArc};
-use threshold_crypto::SecretKey;
+use rustler::{Binary, Env, OwnedBinary, ResourceArc};
 use std::io::Write as _;
+use threshold_crypto::SecretKey;
 
 /// Struct to hold SecretKey
 pub struct SkRes {
@@ -48,12 +48,12 @@ fn sk_reveal(sk_arc: SkArc) -> String {
     sk_arc.sk.reveal()
 }
 
-#[rustler::nif(name = "sk_sign")]
+#[rustler::nif(name = "sk_sign", schedule = "DirtyCpu")]
 fn sk_sign<'a>(sk_arc: SkArc, msg: LazyBinary<'a>) -> SigArc {
     ResourceArc::new(SigRes(sk_arc.sk.sign(msg)))
 }
 
-#[rustler::nif(name = "sk_decrypt")]
+#[rustler::nif(name = "sk_decrypt", schedule = "DirtyCpu")]
 fn sk_decrypt<'a>(env: Env<'a>, sk_arc: SkArc, cipher_arc: CiphertextArc) -> Binary<'a> {
     let decrypted = sk_arc.sk.decrypt(&cipher_arc.0).unwrap();
     let mut binary = OwnedBinary::new(decrypted.len()).unwrap();

--- a/native/sk_set.rs
+++ b/native/sk_set.rs
@@ -28,7 +28,7 @@ fn sk_set_threshold(sk_set_arc: SKSetArc) -> usize {
     sk_set_arc.sk_set.threshold()
 }
 
-#[rustler::nif(name = "sk_set_public_keys")]
+#[rustler::nif(name = "sk_set_public_keys", schedule = "DirtyCpu")]
 fn sk_set_public_keys(sk_set_arc: SKSetArc) -> PKSetArc {
     ResourceArc::new(PKSetRes {
         pk_set: sk_set_arc.sk_set.public_keys(),

--- a/native/sk_share.rs
+++ b/native/sk_share.rs
@@ -21,14 +21,14 @@ pub fn load(env: Env) -> bool {
     true
 }
 
-#[rustler::nif(name = "sk_share_decryption_share")]
+#[rustler::nif(name = "sk_share_decryption_share", schedule = "DirtyCpu")]
 fn sk_share_decryption_share(sk_share_arc: SKShareArc, cipher_arc: CiphertextArc) -> DecShareArc {
     ResourceArc::new(DecShareRes {
         dec_share: sk_share_arc.share.decrypt_share(&cipher_arc.0).unwrap(),
     })
 }
 
-#[rustler::nif(name = "sk_share_sign")]
+#[rustler::nif(name = "sk_share_sign", schedule = "DirtyCpu")]
 fn sk_share_sign<'a>(sk_share_arc: SKShareArc, msg: LazyBinary<'a>) -> SigShareArc {
     ResourceArc::new(SigShareRes {
         sig_share: sk_share_arc.share.sign(msg),


### PR DESCRIPTION
Between testing on @Vagabond's monster build box, my 2013 trashcan, and GHA actions in #12, the following NIFs were found to be too slow (> 1 ms runtime) and need to use a dirty scheduler:

```
 ciphertext_verify
 commitment_bivar_poly
 commitment_poly
 deserialize_bivar_commitment
 deserialize_fr
 eval_bivar_commitment
 eval_uni_poly
 g1_affine_mul
 into_fr
 pk_encrypt
 pk_set_combine_signatures
 pk_set_decrypt
 pk_set_deserialize
 pk_share_verify_decryption_share
 pk_share_verify_signature_share
 pk_verify
 row_bivar_commitment
 serialize_bivar_commitment
 serialize_fr
 sk_decrypt
 sk_set_public_keys
 sk_share_decryption_share
 sk_share_sign
 sk_sign
```
