### PR TITLE
Do not statically link to musl-libc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,5 +4,8 @@ rustflags = [
     "-C", "link-arg=dynamic_lookup",
 ]
 
+[target.x86_64-unknown-linux-musl]
+crt_static = false
+
 [build]
 target-dir = "_build/native"


### PR DESCRIPTION
This config change tells rustc to dynamically link against musl, instead of the default which is static.